### PR TITLE
Components and maven plugins upgrades

### DIFF
--- a/dependencies-check-rules.xml
+++ b/dependencies-check-rules.xml
@@ -10,4 +10,13 @@
 		<ignoreVersion type="regex">.*[\.-](?i)rc?[0-9]*$</ignoreVersion>
 		<ignoreVersion type="regex">.*[\.-](?i)draft.*$</ignoreVersion>
 	</ignoreVersions>
+
+	<rules>
+		<!-- Ignore a strange version of dom4j -->
+		<rule groupId="dom4j" artifactId="dom4j">
+			<ignoreVersions>
+				<ignoreVersion>20040902.021138</ignoreVersion>
+			</ignoreVersions>
+		</rule>
+	</rules>
 </ruleset>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
     <plugin.assembly.version>2.5.2</plugin.assembly.version>
     <plugin.changes.version>2.6</plugin.changes.version>
     <plugin.checkstyle.version>2.9</plugin.checkstyle.version>
-    <plugin.clean.version>2.4.1</plugin.clean.version>
+    <plugin.clean.version>2.6.1</plugin.clean.version>
     <plugin.compiler.version>2.3.2</plugin.compiler.version>
     <plugin.dependency.version>2.3</plugin.dependency.version>
     <plugin.deploy.version>2.7</plugin.deploy.version>

--- a/pom.xml
+++ b/pom.xml
@@ -98,9 +98,14 @@
     <commons-io.version>2.1</commons-io.version>
     <dom4j.version>1.6.1</dom4j.version>
     <jaxen.version>1.1.1</jaxen.version>
+
+    <!-- Test dependencies version -->
     <junit.version>4.10</junit.version>
     <betamax.version>1.0</betamax.version>
     <groovy.version>1.8.4</groovy.version>
+
+    <!-- Report dependencies version -->
+    <report.doxia.version>1.2</report.doxia.version>
 
     <!-- Plugins version -->
     <plugin.antrun.version>1.7</plugin.antrun.version>
@@ -129,6 +134,15 @@
     <plugin.surefire.version>2.10</plugin.surefire.version>
     <plugin.taglist.version>2.4</plugin.taglist.version>
     <plugin.versions.version>2.1</plugin.versions.version>
+
+    <!-- Extensions version -->
+    <extension.maven-scm-provider-gitexe.version>1.3</extension.maven-scm-provider-gitexe.version>
+    <extension.maven-scm-manager-plexus.version>1.3</extension.maven-scm-manager-plexus.version>
+    <extension.wagon-gitsite.version>0.3.1</extension.wagon-gitsite.version>
+
+    <!-- Doclet version -->
+    <doclet.doclava.version>1.0.3</doclet.doclava.version>
+
   </properties>
 
   <build>
@@ -161,12 +175,12 @@
           <dependency>
             <groupId>org.apache.maven.doxia</groupId>
             <artifactId>doxia-decoration-model</artifactId>
-            <version>1.2</version>
+            <version>${report.doxia.version}</version>
           </dependency>
           <dependency>
             <groupId>org.apache.maven.doxia</groupId>
             <artifactId>doxia-module-confluence</artifactId>
-            <version>1.2</version>
+            <version>${report.doxia.version}</version>
           </dependency>
         </dependencies>
       </plugin>
@@ -285,17 +299,17 @@
       <extension>
         <groupId>org.apache.maven.scm</groupId>
         <artifactId>maven-scm-provider-gitexe</artifactId>
-        <version>1.3</version>
+        <version>${extension.maven-scm-provider-gitexe.version}</version>
       </extension>
       <extension>
         <groupId>org.apache.maven.scm</groupId>
         <artifactId>maven-scm-manager-plexus</artifactId>
-        <version>1.3</version>
+        <version>${extension.maven-scm-manager-plexus.version}</version>
       </extension>
       <extension>
         <groupId>org.kathrynhuxtable.maven.wagon</groupId>
         <artifactId>wagon-gitsite</artifactId>
-        <version>0.3.1</version>
+        <version>${extension.wagon-gitsite.version}</version>
       </extension>
     </extensions>
   </build>
@@ -332,7 +346,7 @@
           <docletArtifact>
             <groupId>com.google.doclava</groupId>
             <artifactId>doclava</artifactId>
-            <version>1.0.3</version>
+            <version>${doclet.doclava.version}</version>
           </docletArtifact>
           <doclet>com.google.doclava.Doclava</doclet>
           <!-- bootclasspath required by Sun's JVM -->
@@ -466,6 +480,7 @@
       <artifactId>jaxen</artifactId>
       <version>${jaxen.version}</version>
     </dependency>
+
     <!-- Test -->
     <dependency>
       <groupId>junit</groupId>
@@ -479,6 +494,7 @@
       <version>${betamax.version}</version>
       <scope>test</scope>
     </dependency>
+    <!-- needed for betamax -->
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-all</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
     <plugin.antrun.version>1.7</plugin.antrun.version>
     <plugin.assembly.version>2.5.2</plugin.assembly.version>
     <plugin.changes.version>2.6</plugin.changes.version>
-    <plugin.checkstyle.version>2.8</plugin.checkstyle.version>
+    <plugin.checkstyle.version>2.9</plugin.checkstyle.version>
     <plugin.clean.version>2.4.1</plugin.clean.version>
     <plugin.compiler.version>2.3.2</plugin.compiler.version>
     <plugin.dependency.version>2.3</plugin.dependency.version>
@@ -442,6 +442,11 @@
           <findbugsXmlOutput>true</findbugsXmlOutput>
           <findbugsXmlWithMessages>true</findbugsXmlWithMessages>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>${plugin.checkstyle.version}</version>
       </plugin>
     </plugins>
   </reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <!-- Dependencies version -->
     <apache.httpcomponents.version>4.3.6</apache.httpcomponents.version>
     <commons-lang.version>2.6</commons-lang.version>
-    <commons-io.version>2.1</commons-io.version>
+    <commons-io.version>2.4</commons-io.version>
     <dom4j.version>1.6.1</dom4j.version>
     <jaxen.version>1.1.6</jaxen.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
     <plugin.changes.version>2.6</plugin.changes.version>
     <plugin.checkstyle.version>2.9</plugin.checkstyle.version>
     <plugin.clean.version>2.6.1</plugin.clean.version>
-    <plugin.compiler.version>2.3.2</plugin.compiler.version>
+    <plugin.compiler.version>3.2</plugin.compiler.version>
     <plugin.dependency.version>2.3</plugin.dependency.version>
     <plugin.deploy.version>2.7</plugin.deploy.version>
     <plugin.eclipse.version>2.8</plugin.eclipse.version>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
 
     <!-- Test dependencies version -->
     <junit.version>4.11</junit.version>
-    <betamax.version>1.0</betamax.version>
+    <betamax.version>1.1.2</betamax.version>
     <groovy.version>1.8.4</groovy.version>
 
     <!-- Report dependencies version -->
@@ -489,7 +489,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.robfletcher</groupId>
+      <groupId>co.freeside</groupId>
       <artifactId>betamax</artifactId>
       <version>${betamax.version}</version>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     <!-- Test dependencies version -->
     <junit.version>4.11</junit.version>
     <betamax.version>1.1.2</betamax.version>
-    <groovy.version>1.8.4</groovy.version>
+    <groovy.version>2.3.8</groovy.version>
 
     <!-- Report dependencies version -->
     <report.doxia.version>1.2</report.doxia.version>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
     <groovy.version>2.3.8</groovy.version>
 
     <!-- Report dependencies version -->
-    <report.doxia.version>1.2</report.doxia.version>
+    <report.doxia.version>1.6</report.doxia.version>
 
     <!-- Plugins version -->
     <plugin.antrun.version>1.7</plugin.antrun.version>
@@ -129,7 +129,7 @@
     <plugin.project-info-reports.version>2.4</plugin.project-info-reports.version>
     <plugin.release.version>2.2.1</plugin.release.version>
     <plugin.resources.version>2.5</plugin.resources.version>
-    <plugin.site.version>3.0</plugin.site.version>
+    <plugin.site.version>3.4</plugin.site.version>
     <plugin.source.version>2.1.2</plugin.source.version>
     <plugin.surefire.version>2.10</plugin.surefire.version>
     <plugin.taglist.version>2.4</plugin.taglist.version>

--- a/pom.xml
+++ b/pom.xml
@@ -116,21 +116,21 @@
     <plugin.antrun.version>1.7</plugin.antrun.version>
     <plugin.assembly.version>2.5.2</plugin.assembly.version>
     <plugin.changes.version>2.6</plugin.changes.version>
-    <plugin.checkstyle.version>2.9</plugin.checkstyle.version>
+    <plugin.checkstyle.version>2.13</plugin.checkstyle.version>
     <plugin.clean.version>2.6.1</plugin.clean.version>
     <plugin.compiler.version>3.2</plugin.compiler.version>
     <plugin.dependency.version>2.3</plugin.dependency.version>
     <plugin.deploy.version>2.7</plugin.deploy.version>
     <plugin.eclipse.version>2.8</plugin.eclipse.version>
     <plugin.enforcer.version>1.0.1</plugin.enforcer.version>
-    <plugin.findbugs.version>2.3.2</plugin.findbugs.version>
+    <plugin.findbugs.version>3.0.0</plugin.findbugs.version>
     <plugin.gpg.version>1.4</plugin.gpg.version>
     <plugin.help.version>2.1.1</plugin.help.version>
     <plugin.install.version>2.3.1</plugin.install.version>
     <plugin.jar.version>2.3.2</plugin.jar.version>
     <plugin.javadoc.version>2.8</plugin.javadoc.version>
     <plugin.jxr.version>2.3</plugin.jxr.version>
-    <plugin.pmd.version>2.6</plugin.pmd.version>
+    <plugin.pmd.version>3.3</plugin.pmd.version>
     <plugin.project-info-reports.version>2.4</plugin.project-info-reports.version>
     <plugin.release.version>2.2.1</plugin.release.version>
     <plugin.resources.version>2.5</plugin.resources.version>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <jaxen.version>1.1.6</jaxen.version>
 
     <!-- Test dependencies version -->
-    <junit.version>4.11</junit.version>
+    <junit.version>4.12</junit.version>
     <betamax.version>1.1.2</betamax.version>
     <groovy.version>2.3.8</groovy.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <jaxen.version>1.1.6</jaxen.version>
 
     <!-- Test dependencies version -->
-    <junit.version>4.10</junit.version>
+    <junit.version>4.11</junit.version>
     <betamax.version>1.0</betamax.version>
     <groovy.version>1.8.4</groovy.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -119,21 +119,21 @@
     <plugin.checkstyle.version>2.13</plugin.checkstyle.version>
     <plugin.clean.version>2.6.1</plugin.clean.version>
     <plugin.compiler.version>3.2</plugin.compiler.version>
-    <plugin.dependency.version>2.3</plugin.dependency.version>
-    <plugin.deploy.version>2.7</plugin.deploy.version>
-    <plugin.eclipse.version>2.8</plugin.eclipse.version>
-    <plugin.enforcer.version>1.0.1</plugin.enforcer.version>
+    <plugin.dependency.version>2.9</plugin.dependency.version>
+    <plugin.deploy.version>2.8.2</plugin.deploy.version>
+    <plugin.eclipse.version>2.9</plugin.eclipse.version>
+    <plugin.enforcer.version>1.3.1</plugin.enforcer.version>
     <plugin.findbugs.version>3.0.0</plugin.findbugs.version>
-    <plugin.gpg.version>1.4</plugin.gpg.version>
-    <plugin.help.version>2.1.1</plugin.help.version>
-    <plugin.install.version>2.3.1</plugin.install.version>
-    <plugin.jar.version>2.3.2</plugin.jar.version>
+    <plugin.gpg.version>1.5</plugin.gpg.version>
+    <plugin.help.version>2.2</plugin.help.version>
+    <plugin.install.version>2.5.2</plugin.install.version>
+    <plugin.jar.version>2.5</plugin.jar.version>
     <plugin.javadoc.version>2.10.1</plugin.javadoc.version>
     <plugin.jxr.version>2.3</plugin.jxr.version>
     <plugin.pmd.version>3.3</plugin.pmd.version>
     <plugin.project-info-reports.version>2.4</plugin.project-info-reports.version>
-    <plugin.release.version>2.2.1</plugin.release.version>
-    <plugin.resources.version>2.5</plugin.resources.version>
+    <plugin.release.version>2.5.1</plugin.release.version>
+    <plugin.resources.version>2.7</plugin.resources.version>
     <plugin.site.version>3.4</plugin.site.version>
     <plugin.source.version>2.4</plugin.source.version>
     <plugin.surefire.version>2.18</plugin.surefire.version>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
 
     <!-- Plugins version -->
     <plugin.antrun.version>1.7</plugin.antrun.version>
-    <plugin.assembly.version>2.2.2</plugin.assembly.version>
+    <plugin.assembly.version>2.5.2</plugin.assembly.version>
     <plugin.changes.version>2.6</plugin.changes.version>
     <plugin.checkstyle.version>2.8</plugin.checkstyle.version>
     <plugin.clean.version>2.4.1</plugin.clean.version>

--- a/pom.xml
+++ b/pom.xml
@@ -128,15 +128,15 @@
     <plugin.help.version>2.1.1</plugin.help.version>
     <plugin.install.version>2.3.1</plugin.install.version>
     <plugin.jar.version>2.3.2</plugin.jar.version>
-    <plugin.javadoc.version>2.8</plugin.javadoc.version>
+    <plugin.javadoc.version>2.10.1</plugin.javadoc.version>
     <plugin.jxr.version>2.3</plugin.jxr.version>
     <plugin.pmd.version>3.3</plugin.pmd.version>
     <plugin.project-info-reports.version>2.4</plugin.project-info-reports.version>
     <plugin.release.version>2.2.1</plugin.release.version>
     <plugin.resources.version>2.5</plugin.resources.version>
     <plugin.site.version>3.4</plugin.site.version>
-    <plugin.source.version>2.1.2</plugin.source.version>
-    <plugin.surefire.version>2.10</plugin.surefire.version>
+    <plugin.source.version>2.4</plugin.source.version>
+    <plugin.surefire.version>2.18</plugin.surefire.version>
     <plugin.taglist.version>2.4</plugin.taglist.version>
     <plugin.versions.version>2.1</plugin.versions.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -81,10 +81,15 @@
       <id>gschueler</id>
       <name>Greg Schueler</name>
     </developer>
-      <developer>
-          <id>connaryscott</id>
-          <name>Chuck Scott</name>
-      </developer>
+    <developer>
+      <id>connaryscott</id>
+      <name>Chuck Scott</name>
+    </developer>
+    <developer>
+      <id>Sylvain-Bugat</id>
+      <name>Sylvain Bugat</name>
+      <url>https://github.com/Sylvain-Bugat</url>
+    </developer>
   </developers>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     <commons-lang.version>2.6</commons-lang.version>
     <commons-io.version>2.1</commons-io.version>
     <dom4j.version>1.6.1</dom4j.version>
-    <jaxen.version>1.1.1</jaxen.version>
+    <jaxen.version>1.1.6</jaxen.version>
 
     <!-- Test dependencies version -->
     <junit.version>4.10</junit.version>

--- a/src/test/java/org/rundeck/api/ExecutionQueryParametersTest.java
+++ b/src/test/java/org/rundeck/api/ExecutionQueryParametersTest.java
@@ -1,6 +1,6 @@
 package org.rundeck.api;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.rundeck.api.query.ExecutionQuery;
 

--- a/src/test/java/org/rundeck/api/RundeckClientTest.java
+++ b/src/test/java/org/rundeck/api/RundeckClientTest.java
@@ -15,10 +15,6 @@
  */
 package org.rundeck.api;
 
-import betamax.Betamax;
-import betamax.MatchRule;
-import betamax.Recorder;
-import betamax.TapeMode;
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Before;
@@ -27,6 +23,11 @@ import org.junit.Test;
 import org.rundeck.api.domain.*;
 import org.rundeck.api.query.ExecutionQuery;
 import org.rundeck.api.util.PagedResults;
+
+import co.freeside.betamax.Betamax;
+import co.freeside.betamax.MatchRule;
+import co.freeside.betamax.Recorder;
+import co.freeside.betamax.TapeMode;
 
 import java.io.*;
 import java.util.*;

--- a/src/test/java/org/rundeck/api/RundeckClientTest.java
+++ b/src/test/java/org/rundeck/api/RundeckClientTest.java
@@ -34,7 +34,7 @@ import java.util.*;
 
 /**
  * Test the {@link RundeckClient}. Uses betamax to unit-test HTTP requests without a live RunDeck instance.
- * 
+ *
  * @author Vincent Behar
  */
 public class RundeckClientTest {
@@ -943,7 +943,7 @@ public class RundeckClientTest {
         Assert.assertEquals("api-java-client-test-adhoc-script-as-user1", test.getStartedBy());
         Assert.assertEquals(RundeckExecution.ExecutionStatus.RUNNING, test.getStatus());
     }
-    
+
     @Test
     @Betamax(tape = "trigger_adhoc_script_as_user_unauthorized")
     public void triggerAdhocScriptAsUserUnauthorized() throws Exception {
@@ -1329,7 +1329,7 @@ public class RundeckClientTest {
     @Betamax(tape = "execution_output_basic", mode = TapeMode.READ_ONLY)
     public void executionOutputBasic() throws Exception {
         final RundeckClient client = createClient(TEST_TOKEN_6, 10);
-        RundeckOutput output = client.getJobExecutionOutput(146L,0,0L,-1);
+        RundeckOutput output = client.getExecutionOutput(146L,0,0L,-1);
 
         Assert.assertEquals(new Long(1602), output.getExecDuration());
         Assert.assertEquals(new Long(146), output.getExecutionId());

--- a/src/test/java/org/rundeck/api/generator/ProjectConfigGeneratorTest.java
+++ b/src/test/java/org/rundeck/api/generator/ProjectConfigGeneratorTest.java
@@ -1,14 +1,11 @@
 package org.rundeck.api.generator;
 
-import junit.framework.Assert;
 import org.dom4j.Document;
 import org.dom4j.Element;
 import org.dom4j.io.XMLWriter;
+import org.junit.Assert;
 import org.junit.Test;
 import org.rundeck.api.domain.ProjectConfig;
-import org.rundeck.api.domain.RundeckProject;
-
-import java.io.UnsupportedEncodingException;
 
 /**
  * ProjectConfigGeneratorTest is ...

--- a/src/test/java/org/rundeck/api/generator/ProjectGeneratorTest.java
+++ b/src/test/java/org/rundeck/api/generator/ProjectGeneratorTest.java
@@ -1,7 +1,7 @@
 package org.rundeck.api.generator;
 
-import junit.framework.Assert;
 import org.dom4j.Document;
+import org.junit.Assert;
 import org.junit.Test;
 import org.rundeck.api.domain.RundeckProject;
 

--- a/src/test/java/org/rundeck/api/parser/BaseStateParserTest.java
+++ b/src/test/java/org/rundeck/api/parser/BaseStateParserTest.java
@@ -1,13 +1,12 @@
 package org.rundeck.api.parser;
 
-import junit.framework.Assert;
 import org.dom4j.Document;
+import org.junit.Assert;
 import org.junit.Test;
 import org.rundeck.api.domain.BaseState;
 import org.rundeck.api.domain.RundeckWFExecState;
 
 import java.io.InputStream;
-import java.util.Date;
 
 /**
  * $INTERFACE is ... User: greg Date: 1/18/14 Time: 8:33 AM

--- a/src/test/java/org/rundeck/api/parser/ExecutionStateParserTest.java
+++ b/src/test/java/org/rundeck/api/parser/ExecutionStateParserTest.java
@@ -1,7 +1,7 @@
 package org.rundeck.api.parser;
 
-import junit.framework.Assert;
 import org.dom4j.Document;
+import org.junit.Assert;
 import org.junit.Test;
 import org.rundeck.api.domain.RundeckExecutionState;
 import org.rundeck.api.domain.RundeckNodeIdentity;

--- a/src/test/java/org/rundeck/api/parser/IndexedWorkflowStepStateParserTest.java
+++ b/src/test/java/org/rundeck/api/parser/IndexedWorkflowStepStateParserTest.java
@@ -1,10 +1,9 @@
 package org.rundeck.api.parser;
 
-import junit.framework.Assert;
 import org.dom4j.Document;
 import org.dom4j.DocumentException;
 import org.dom4j.DocumentHelper;
-import org.dom4j.Element;
+import org.junit.Assert;
 import org.junit.Test;
 import org.rundeck.api.domain.WorkflowState;
 import org.rundeck.api.domain.WorkflowStepContextState;

--- a/src/test/java/org/rundeck/api/parser/ProjectConfigPropertyParserTest.java
+++ b/src/test/java/org/rundeck/api/parser/ProjectConfigPropertyParserTest.java
@@ -1,12 +1,9 @@
 package org.rundeck.api.parser;
 
-import junit.framework.Assert;
 import org.dom4j.Document;
+import org.junit.Assert;
 import org.junit.Test;
-import org.junit.runners.JUnit4;
 import org.rundeck.api.domain.ConfigProperty;
-import org.rundeck.api.domain.ProjectConfig;
-
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 

--- a/src/test/java/org/rundeck/api/parser/WorkflowStateParserTest.java
+++ b/src/test/java/org/rundeck/api/parser/WorkflowStateParserTest.java
@@ -1,13 +1,12 @@
 package org.rundeck.api.parser;
 
-import junit.framework.Assert;
 import org.dom4j.Document;
+import org.junit.Assert;
 import org.junit.Test;
 import org.rundeck.api.domain.*;
 
 import java.io.InputStream;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.HashSet;
 
 /**

--- a/src/test/java/org/rundeck/api/parser/WorkflowStepStateParserTest.java
+++ b/src/test/java/org/rundeck/api/parser/WorkflowStepStateParserTest.java
@@ -1,7 +1,7 @@
 package org.rundeck.api.parser;
 
-import junit.framework.Assert;
 import org.dom4j.Document;
+import org.junit.Assert;
 import org.junit.Test;
 import org.rundeck.api.domain.*;
 


### PR DESCRIPTION
Components upgrades:
* Jaxen 1.1.1 -> 1.1.6
* Commons-io 2.1 -> 2.4

Test components upgrades:
* Junit 4.10 -> 4.12 (fix some deprecated)
* Betamax 1.0 -> 1.1.2 (changind groupdId and imports to co.freeside)
* Groovy 1.8.4 -> 2.3.8 (used by betamax)

Plugins upgrades:
* site 3.0 -> 3.4 (Needs Doxia v1.6)
* assembly 2.2.2 -> 2.5.2
* clean 2.4.1 -> 2.6.1
* compiler 2.3.2 -> 3.2
* checkstyle 2.8 -> 2.13 (and activate report)
* findbugs 2.3.2 -> 3.0.0
* javadoc 2.8 -> 2.10.1
* source 2.1.2 -> 2.4
* surefire 2.10 -> 2.18
* PMD 2.6 -> 3.3
* dependency 2.3 -> 2.9
* deploy 2.7 -> 2.8.2
* eclipse 2.8 -> 2.9
* enforcer 1.0.1 -> 1.3.1
* GNUpg 1.4 -> 1.5
* helper 2.1.1 -> 2.2
* install 2.3.1 -> 2.5.2
* jar 2.3.2 -> 2.5
* release 2.2.1 -> 2.5.1
* resources 2.5 -> 2.7

Misc:
* Externalization of versions as properties in pom.xml
* Ignore dom4j strange version in version report

Local unit tests OK and generated client tests on rundeck monitor OK
