### PR TITLE
Get RundeckClient.ping() to work with Rundeck's preauthenticated mode

### DIFF
--- a/src/main/java/org/rundeck/api/ApiCall.java
+++ b/src/main/java/org/rundeck/api/ApiCall.java
@@ -84,8 +84,17 @@ class ApiCall {
      */
     public void ping() throws RundeckApiException {
         CloseableHttpClient httpClient = instantiateHttpClient();
+        String UrlToPing = null;
+        if (client.getToken() != null || client.getSessionID() != null) {
+            // The preauthenticated mode always returns a HTTP 403 if we make a
+            // call to the root URL of the Rundeck instance. Hence, make a call to
+            // /api/<version>/system/info instead
+            UrlToPing = client.getUrl() + client.getApiEndpoint() + "/system/info" ;
+        } else {
+            UrlToPing = client.getUrl() ;
+        }
         try {
-            HttpResponse response = httpClient.execute(new HttpGet(client.getUrl() + client.getApiEndpoint() + "/system/info" ));
+            HttpResponse response = httpClient.execute(new HttpGet(UrlToPing));
             if (response.getStatusLine().getStatusCode() / 100 != 2) {
                 throw new RundeckApiException("Invalid HTTP response '" + response.getStatusLine() + "' when pinging "
                                               + client.getUrl());

--- a/src/main/java/org/rundeck/api/ApiCall.java
+++ b/src/main/java/org/rundeck/api/ApiCall.java
@@ -85,7 +85,7 @@ class ApiCall {
     public void ping() throws RundeckApiException {
         CloseableHttpClient httpClient = instantiateHttpClient();
         try {
-            HttpResponse response = httpClient.execute(new HttpGet(client.getUrl()));
+            HttpResponse response = httpClient.execute(new HttpGet(client.getUrl() + client.getApiEndpoint() + "/system/info" ));
             if (response.getStatusLine().getStatusCode() / 100 != 2) {
                 throw new RundeckApiException("Invalid HTTP response '" + response.getStatusLine() + "' when pinging "
                                               + client.getUrl());


### PR DESCRIPTION
Rundeck introduced a [preauthenticated](http://rundeck.org/docs/administration/authenticating-users.html#preauthenticated-mode) mode recently, to offload authentication to downstream systems like reverse proxies. In this mode, the `ping` method of the `RundeckClient` fails for token logins because the server always returns an HTTP 403.

This patch tests whether authentication for the Rundeck instance is login or auth token based, and pings `/api/<version>/system/info` instead of the root Rundeck URL if token based authentication is being used.

Tested with Rundeck 2.7.2-1, Jenkins 2.65 and OAuth2 Proxy (with `skip_auth_regex`/`--skip-auth-regex` enabled).